### PR TITLE
Sleep timer

### DIFF
--- a/elevator.rb
+++ b/elevator.rb
@@ -13,7 +13,6 @@ class Elevator
 
   def call(floor)
     @queued_floors << floor
-    # move
   end
 
   def move

--- a/elevator.rb
+++ b/elevator.rb
@@ -17,8 +17,21 @@ class Elevator
 
   def move
     if @queued_floors.empty?
+      floor_difference = (@current_floor..@parked_floor)
+      floor_difference.each do |floor|
+        sleep 5
+      end
       @current_floor = @parked_floor
+    elsif @queued_floors[0] > @current_floor
+      floor_difference = (@current_floor..@queued_floors[0])
+      floor_difference.each do |floor|
+        sleep 5
+      end
+      @current_floor = @queued_floors.shift
     else
+      @current_floor.downto(@queued_floors[0]) do |floor|
+        sleep 5
+      end
       @current_floor = @queued_floors.shift
     end
   end

--- a/spec/car_spec.rb
+++ b/spec/car_spec.rb
@@ -39,4 +39,15 @@ RSpec.describe 'Test that the elevator' do
       expect(@elevator.current_floor).to eq(@elevator.parked_floor)
     end
   end
+
+  it 'moves at a normal speed from floor to floor' do
+    @elevator.call(4)
+    start_time = Time.now
+    @elevator.move
+    end_time = Time.now
+
+    #5 seconds to move from one floor to the next
+    difference = end_time - start_time
+    expect(difference).to be > 20
+  end
 end


### PR DESCRIPTION
In a real elevator, it takes a few seconds to move from one floor to the next.  So far in this code, the elevator moves from one floor to the next instantaneously.  It is desired to slow this 'movement' down to better match what a real life elevator does.

Wrote an RSpec that would check the time it takes to move four floors.  Five seconds was chosed as a reasonable time to move from floor to floor.

Wrote code to slow down the movement of the elevator, using a sleep timer in the #move method.  The code uses ranges, based on the difference between current floor and called floor.  Since Ruby does not allow for iterating over reverse ranges, it was necessary to add logic to the #move method to account for when the elevator is called to a lower floor from a higher floor.  The .downto() function was used for this case.

Future work:
- The #move method is large and needs refactoring.
- Could add an until block at the outset of the #move method, which will continue to cycle through the movements until the queued_floor array is empty (meaning that the elevator is not being called to any floors).  